### PR TITLE
Deploy: Save changes — RR generation + CSV + dev mock

### DIFF
--- a/lib/datCsvBuilder.js
+++ b/lib/datCsvBuilder.js
@@ -87,7 +87,7 @@ function contactVariants() {
   return ['email', 'primary phone'];
 }
 
-function baseRowFrom(lane, origin, dest, contact, usedRefIds = new Set()) {
+function baseRowFrom(lane, origin, dest, contact, usedRefIds = new Set(), refSuffix = '') {
   // Build a single CSV row (object keyed by DAT_HEADERS)
   // Ensure pickup latest defaults to pickup earliest if empty
   const pickupLatest = lane.pickup_latest || lane.pickup_earliest;
@@ -106,18 +106,28 @@ function baseRowFrom(lane, origin, dest, contact, usedRefIds = new Set()) {
     }
   }
   
-  // Ensure reference ID uniqueness within this CSV export
-  let uniqueRefId = referenceId;
+  // Apply optional suffix for generated postings (keeps mapping to parent RR)
+  let uniqueRefId = referenceId + (refSuffix || '');
+  // Ensure format still starts with RR and digits; if suffix breaks pattern, allow it but keep short
+  if (!/^RR\d{5}/.test(uniqueRefId)) {
+    // If parent referenceId was missing or malformed, fall back to numeric id generation
+    const laneId = parseInt(lane.id, 10);
+    if (isNaN(laneId)) {
+      uniqueRefId = `RR${String(Math.floor(Math.random() * 100000)).padStart(5, '0')}${refSuffix || ''}`;
+    } else {
+      const numericId = String(Math.abs(laneId) % 100000).padStart(5, '0');
+      uniqueRefId = `RR${numericId}${refSuffix || ''}`;
+    }
+  }
   let counter = 1;
   while (usedRefIds.has(uniqueRefId)) {
-    // Generate alternative unique reference ID
-    const baseNum = parseInt(uniqueRefId.slice(2), 10);
+    // If collision, append/roll the numeric suffix (last-resort)
+    const baseNum = parseInt(uniqueRefId.slice(2, 7), 10) || 0;
     const newNum = String((baseNum + counter) % 100000).padStart(5, '0');
-    uniqueRefId = `RR${newNum}`;
+    const suffix = refSuffix || '';
+    uniqueRefId = `RR${newNum}${suffix}`; // allow longer if suffix present
     counter++;
-    
-    // Safety check to prevent infinite loop
-    if (counter > 100000) {
+    if (counter > 10000) {
       uniqueRefId = `RR${String(Math.floor(Math.random() * 100000)).padStart(5, '0')}`;
       break;
     }
@@ -150,7 +160,7 @@ function baseRowFrom(lane, origin, dest, contact, usedRefIds = new Set()) {
     'Destination Postal Code': dest.zip || '', // Column U: Plain text for DAT compatibility
     'Comment': lane.comment || '', // Optional: 140 char max
     'Commodity': lane.commodity || '', // Optional: 70 char max
-    'Reference ID': uniqueRefId.slice(0, 8) // Plain text format - DAT compatible (no Excel quotes)
+  'Reference ID': uniqueRefId.slice(0, 8) // Plain text format - DAT compatible (no Excel quotes)
   };
 }
 
@@ -230,11 +240,14 @@ export function rowsFromBaseAndPairs(lane, baseOrigin, baseDest, pairs, preferFi
   
   const rows = [];
 
+  // Assign numeric suffixes to generated postings so each posting becomes RR123451, RR123452, etc.
   for (let i = 0; i < postings.length; i++) {
     const posting = postings[i];
+    // Base posting (i === 0) keeps the parent RR with no suffix
+    const suffix = i === 0 ? '' : String(i); // 1,2,3...
     for (let j = 0; j < contactMethods.length; j++) {
       const method = contactMethods[j];
-      const row = baseRowFrom(lane, posting.pickup, posting.delivery, method, usedRefIds);
+      const row = baseRowFrom(lane, posting.pickup, posting.delivery, method, usedRefIds, suffix);
       rows.push(row);
     }
   }

--- a/tmp/test-dat-builder.js
+++ b/tmp/test-dat-builder.js
@@ -1,0 +1,39 @@
+const { planPairsForLane, rowsFromBaseAndPairs, toCsv, DAT_HEADERS } = require('../lib/datCsvBuilder');
+
+(async () => {
+  try {
+    const lane = {
+      id: 12345,
+      origin_city: 'Maplesville',
+      origin_state: 'AL',
+      dest_city: 'Birmingham',
+      dest_state: 'AL',
+      equipment_code: 'FD',
+      length_ft: 48,
+      pickup_earliest: '2025-09-15',
+      pickup_latest: '2025-09-16',
+      randomize_weight: false,
+      weight_lbs: 45000,
+      reference_id: 'RR12345'
+    };
+
+    // Mock a small set of pairs
+    const baseOrigin = { city: lane.origin_city, state: lane.origin_state };
+    const baseDest = { city: lane.dest_city, state: lane.dest_state };
+    const pairs = [
+      { pickup: baseOrigin, delivery: baseDest, score: 0.8 },
+      { pickup: { city: 'Selma', state: 'AL' }, delivery: { city: 'Tuscaloosa', state: 'AL' }, score: 0.6 },
+      { pickup: { city: 'Montgomery', state: 'AL' }, delivery: { city: 'Mobile', state: 'AL' }, score: 0.5 }
+    ];
+
+    const rows = rowsFromBaseAndPairs(lane, baseOrigin, baseDest, pairs, true);
+    console.log('Generated rows count:', rows.length);
+    console.log('Sample rows refs:', rows.slice(0,6).map(r => r['Reference ID']));
+
+    const csv = toCsv(DAT_HEADERS, rows);
+    console.log('CSV first lines:\n', csv.split('\r\n').slice(0,5).join('\n'));
+  } catch (e) {
+    console.error('Test failed:', e);
+    process.exit(1);
+  }
+})();

--- a/tmp/test-dat-builder.mjs
+++ b/tmp/test-dat-builder.mjs
@@ -1,0 +1,38 @@
+import { planPairsForLane, rowsFromBaseAndPairs, toCsv, DAT_HEADERS } from '../lib/datCsvBuilder.js';
+
+(async () => {
+  try {
+    const lane = {
+      id: 12345,
+      origin_city: 'Maplesville',
+      origin_state: 'AL',
+      dest_city: 'Birmingham',
+      dest_state: 'AL',
+      equipment_code: 'FD',
+      length_ft: 48,
+      pickup_earliest: '2025-09-15',
+      pickup_latest: '2025-09-16',
+      randomize_weight: false,
+      weight_lbs: 45000,
+      reference_id: 'RR12345'
+    };
+
+    const baseOrigin = { city: lane.origin_city, state: lane.origin_state };
+    const baseDest = { city: lane.dest_city, state: lane.dest_state };
+    const pairs = [
+      { pickup: baseOrigin, delivery: baseDest, score: 0.8 },
+      { pickup: { city: 'Selma', state: 'AL' }, delivery: { city: 'Tuscaloosa', state: 'AL' }, score: 0.6 },
+      { pickup: { city: 'Montgomery', state: 'AL' }, delivery: { city: 'Mobile', state: 'AL' }, score: 0.5 }
+    ];
+
+    const rows = rowsFromBaseAndPairs(lane, baseOrigin, baseDest, pairs, true);
+    console.log('Generated rows count:', rows.length);
+    console.log('Sample rows refs:', rows.slice(0,6).map(r => r['Reference ID']));
+
+    const csv = toCsv(DAT_HEADERS, rows);
+    console.log('CSV first lines:\n', csv.split('\r\n').slice(0,5).join('\n'));
+  } catch (e) {
+    console.error('Test failed:', e);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
This PR saves the recent non-invasive changes:

- Server: auto-generate and attempt to persist Reference ID on lane POST (pages/api/lanes.js)
- Client: accept 'City ST' input, free-text equipment input, pending->covered UX (pages/lanes.js)
- CSV: numeric suffix for generated posting Reference IDs (lib/datCsvBuilder.js)
- Dev: resilient mock Supabase client for missing env vars (utils/supabaseClient.js)
- Test runner: tmp/test-dat-builder.mjs to validate CSV output locally

Notes:
- Migration 'add-reference-id-field.sql' exists and should be applied in production to persist reference_id.
- Dev server runs with a mock DB when SUPABASE env vars are absent; replace with real creds for end-to-end testing.

Please review and merge to trigger deployment.